### PR TITLE
Prevent double slide increment on manual navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,18 +109,31 @@
     <!-- Script pour le carrousel -->
     <script>
         let slideIndex = 0;
+        let slideTimeout;
         showSlides();
 
-        function showSlides() {
-            let i;
-            let slides = document.getElementsByClassName("carousel")[0].children;
-            for (i = 0; i < slides.length; i++) {
+        function showSlides(advance = true) {
+            const slides = document.getElementsByClassName("carousel")[0].children;
+            for (let i = 0; i < slides.length; i++) {
                 slides[i].style.display = "none";
             }
-            slideIndex++;
-            if (slideIndex > slides.length) {slideIndex = 1}
-            slides[slideIndex-1].style.display = "block";
-            setTimeout(showSlides, 4000); // Change image every 4 seconds
+
+            if (advance) {
+                slideIndex++;
+            }
+
+            if (slideIndex > slides.length) {
+                slideIndex = 1;
+            }
+
+            if (slideIndex < 1) {
+                slideIndex = slides.length;
+            }
+
+            slides[slideIndex - 1].style.display = "block";
+
+            clearTimeout(slideTimeout);
+            slideTimeout = setTimeout(() => showSlides(true), 4000); // Change image every 4 seconds
         }
 
         document.querySelector('.prev').addEventListener('click', () => changeSlide(-1));
@@ -128,7 +141,7 @@
 
         function changeSlide(n) {
             slideIndex += n;
-            showSlides();
+            showSlides(false);
         }
 
         // Menu responsive


### PR DESCRIPTION
## Summary
- update the carousel logic so manual navigation does not trigger a double increment
- store the autoplay timeout and reuse the display routine for both automatic and manual changes

## Testing
- Manual verification of prev/next buttons in the terrain carousel

------
https://chatgpt.com/codex/tasks/task_e_68c96b7ef6fc832fb1d39351066feb2b